### PR TITLE
Throw error when a promise is rejected

### DIFF
--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -88,14 +88,20 @@ describe('promiseMiddleware', () => {
   });
 
   it('dispatches reject action with arguments', async () => {
-    await dispatch({
-      type: 'ACTION_TYPE_REJECT',
-      payload: {
-        promise: Promise.reject(err),
-        foo3: 'bar3',
-        foo4: 'bar4'
-      }
-    });
+    try {
+      await dispatch({
+        type: 'ACTION_TYPE_REJECT',
+        payload: {
+          promise: Promise.reject(err),
+          foo3: 'bar3',
+          foo4: 'bar4'
+        }
+      });
+    } catch (e) {
+      // We're not interested in the rejection. We just need to wait until all
+      // dispatching is done.
+      true;
+    }
 
     expect(baseDispatch.calledTwice).to.be.true;
 
@@ -133,7 +139,7 @@ describe('promiseMiddleware', () => {
         foo2: 'bar2'
       }
     });
-    expect(dispatchedResult).to.eventually.equal(foobar);
+    return expect(dispatchedResult).to.eventually.equal(foobar);
   });
 
   it('reject the original promise from dispatch', () => {
@@ -146,7 +152,7 @@ describe('promiseMiddleware', () => {
         foo2: 'bar2'
       }
     });
-    expect(dispatchedResult).to.eventually.be.rejectedWith(err);
+    return expect(dispatchedResult).to.eventually.be.rejectedWith(err);
   });
 
   it('returns the reject and resolve strings with default values', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default function promiseMiddleware(resolvedName, rejectedName) {
           payload: error,
           meta: newAction.payload
         });
-        return error;
+        throw error;
       }
     );
   };


### PR DESCRIPTION
This change makes it possible for client code to distinguish between rejected
and failed promises when attaching then, or catch handlers.  With the previous
behaviour it was impossible to make this distinction (at least using the
promise API).

If the old behaviour is desired, a client can add a catch handler which
returns the error before dispatching:

```
dispatch(myPromise.catch((err) => err))
```
