### PR TITLE
Do not clobber action meta

### DIFF
--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -88,14 +88,20 @@ describe('promiseMiddleware', () => {
   });
 
   it('dispatches reject action with arguments', async () => {
-    await dispatch({
-      type: 'ACTION_TYPE_REJECT',
-      payload: {
-        promise: Promise.reject(err),
-        foo3: 'bar3',
-        foo4: 'bar4'
-      }
-    });
+    try {
+      await dispatch({
+        type: 'ACTION_TYPE_REJECT',
+        payload: {
+          promise: Promise.reject(err),
+          foo3: 'bar3',
+          foo4: 'bar4'
+        }
+      });
+    } catch (e) {
+      // We're not interested in the rejection. We just need to wait until all
+      // dispatching is done.
+      true;
+    }
 
     expect(baseDispatch.calledTwice).to.be.true;
 
@@ -133,7 +139,7 @@ describe('promiseMiddleware', () => {
         foo2: 'bar2'
       }
     });
-    expect(dispatchedResult).to.eventually.equal(foobar);
+    return expect(dispatchedResult).to.eventually.equal(foobar);
   });
 
   it('reject the original promise from dispatch', () => {
@@ -146,7 +152,7 @@ describe('promiseMiddleware', () => {
         foo2: 'bar2'
       }
     });
-    expect(dispatchedResult).to.eventually.be.rejectedWith(err);
+    return expect(dispatchedResult).to.eventually.be.rejectedWith(err);
   });
 
   it('returns the reject and resolve strings with default values', () => {

--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -82,7 +82,9 @@ describe('promiseMiddleware', () => {
       type: resolve('ACTION_TYPE_RESOLVE'),
       payload: foobar,
       meta: {
-        foo2: 'bar2'
+        payload: {
+          foo2: 'bar2'
+        }
       }
     });
   });
@@ -109,9 +111,53 @@ describe('promiseMiddleware', () => {
       type: reject('ACTION_TYPE_REJECT'),
       payload: err,
       meta: {
-        foo3: 'bar3',
-        foo4: 'bar4'
+        payload: {
+          foo3: 'bar3',
+          foo4: 'bar4'
+        }
       }
+    });
+  });
+
+  it('does not overwrite any meta arguments', async () => {
+    await dispatch({
+      type: 'ACTION_TYPE_RESOLVE',
+      payload: {
+        promise: Promise.resolve(foobar),
+        foo2: 'bar2'
+      },
+      meta: {
+        foo3: 'bar3'
+      }
+    });
+
+    expect(baseDispatch.calledTwice).to.be.true;
+
+    expect(baseDispatch.secondCall.args[0]).to.deep.equal({
+      type: resolve('ACTION_TYPE_RESOLVE'),
+      payload: foobar,
+      meta: {
+        foo3: 'bar3',
+        payload: {
+          foo2: 'bar2'
+        }
+      }
+    });
+  });
+
+  it('does not include empty meta payload attribute', async () => {
+    await dispatch({
+      type: 'ACTION_TYPE_RESOLVE',
+      payload: {
+        promise: Promise.resolve(foobar)
+      }
+    });
+
+    expect(baseDispatch.calledTwice).to.be.true;
+
+    expect(baseDispatch.secondCall.args[0]).to.deep.equal({
+      type: resolve('ACTION_TYPE_RESOLVE'),
+      payload: foobar
     });
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default function promiseMiddleware(resolvedName, rejectedName) {
           payload: error,
           meta: newAction.payload
         });
-        return error;
+        throw error;
       }
     );
   };

--- a/src/index.js
+++ b/src/index.js
@@ -43,13 +43,33 @@ export default function promiseMiddleware(resolvedName, rejectedName) {
 
     dispatch(newAction);
 
+    // Create a base for the next action containing the metadata.
+    let nextActionBase = {
+      meta: {
+        ...action.meta,
+        payload: {
+          ...newAction.payload
+        }
+      }
+    }
+
+    if (Object.keys(nextActionBase.meta.payload).length === 0) {
+      // No arguments were given beside the promise, no need to include them
+      // in the meta.
+      delete nextActionBase.meta.payload;
+    }
+    if (Object.keys(nextActionBase.meta).length === 0) {
+      // No meta was included either, remove all meta.
+      delete nextActionBase.meta;
+    }
+
     // (2) Listen to promise and dispatch payload with new actionName
     return action.payload.promise.then(
       (result) => {
         dispatch({
           type: resolve(action.type, resolvedName),
           payload: result,
-          meta: newAction.payload
+          ...nextActionBase
         });
         return result;
       },
@@ -57,7 +77,7 @@ export default function promiseMiddleware(resolvedName, rejectedName) {
         dispatch({
           type: reject(action.type, rejectedName),
           payload: error,
-          meta: newAction.payload
+          ...nextActionBase
         });
         throw error;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export default function promiseMiddleware(resolvedName, rejectedName) {
           ...newAction.payload
         }
       }
-    }
+    };
 
     if (Object.keys(nextActionBase.meta.payload).length === 0) {
       // No arguments were given beside the promise, no need to include them


### PR DESCRIPTION
Previously, if an action had both meta data and payload, the metadata would be clobbered with the payload once the promise had either been rejected or resolved.

Now, the original payload is added to the metadata under the key `payload` preserving any meta already present; unless there was meta under the key `payload` which seems unlikely.

This is a breaking API change.
