### PR TITLE
feat(exports): export resolved and rejected names

### DIFF
--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -1,6 +1,6 @@
 import { spy } from 'sinon';
 import 'babel-polyfill';
-import promiseMiddleware, { resolve, reject, unresolve, unreject } from '../';
+import promiseMiddleware, { resolve, reject, unresolve, unreject, REJECTED_NAME, RESOLVED_NAME } from '../';
 
 function noop() {}
 const GIVE_ME_META = 'GIVE_ME_META';
@@ -15,6 +15,11 @@ function metaMiddleware() {
 describe('before promiseMiddleware is called', () => {
   it('returns the rejected strings with default values', () => {
     expect(reject('MY_ACTION')).to.equal('MY_ACTION_REJECTED');
+  });
+
+  it('export the rejected name and resolved name strings with default values', () => {
+      expect(RESOLVED_NAME).to.equal('_RESOLVED');
+      expect(REJECTED_NAME).to.equal('_REJECTED');
   });
   it('returns the resolved strings with default values', () => {
     expect(resolve('MY_ACTION')).to.equal('MY_ACTION_RESOLVED');

--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -47,6 +47,7 @@ describe('promiseMiddleware', () => {
     foobar = { foo: 'bar' };
     err = new Error();
   });
+
   it('dispatches first action before promise without arguments', () => {
     dispatch({
       type: 'ACTION_TYPE',

--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -18,8 +18,8 @@ describe('before promiseMiddleware is called', () => {
   });
 
   it('export the rejected name and resolved name strings with default values', () => {
-      expect(RESOLVED_NAME).to.equal('_RESOLVED');
-      expect(REJECTED_NAME).to.equal('_REJECTED');
+    expect(RESOLVED_NAME).to.equal('_RESOLVED');
+    expect(REJECTED_NAME).to.equal('_REJECTED');
   });
   it('returns the resolved strings with default values', () => {
     expect(resolve('MY_ACTION')).to.equal('MY_ACTION_RESOLVED');

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ function isPromise(val) {
   return val && typeof val.then === 'function';
 }
 
-export let [RESOLVED_NAME, REJECTED_NAME] = ['_RESOLVED', '_REJECTED'];
+export const [RESOLVED_NAME, REJECTED_NAME] = ['_RESOLVED', '_REJECTED'];
 
 export function resolve(actionName) {
   return actionName + RESOLVED_NAME;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ function isPromise(val) {
   return val && typeof val.then === 'function';
 }
 
-let [RESOLVED_NAME, REJECTED_NAME] = ['_RESOLVED', '_REJECTED'];
+export let [RESOLVED_NAME, REJECTED_NAME] = ['_RESOLVED', '_REJECTED'];
 
 export function resolve(actionName) {
   return actionName + RESOLVED_NAME;

--- a/src/index.js
+++ b/src/index.js
@@ -4,28 +4,19 @@ function isPromise(val) {
   return val && typeof val.then === 'function';
 }
 
-export const [RESOLVED_NAME, REJECTED_NAME] = ['_RESOLVED', '_REJECTED'];
+export const RESOLVED_NAME = '_RESOLVED';
+export const REJECTED_NAME = '_REJECTED';
 
-export function resolve(actionName) {
-  return actionName + RESOLVED_NAME;
-}
+export const resolve = (actionName, resolvedName = RESOLVED_NAME) => actionName + resolvedName;
 
-export function reject(actionName) {
-  return actionName + REJECTED_NAME;
-}
+export const reject = (actionName, rejectedName = REJECTED_NAME) => actionName + rejectedName;
 
-export function unresolve(actionName) {
-  return actionName.replace(RESOLVED_NAME, '');
-}
+export const unresolve = (actionName, resolvedName = RESOLVED_NAME) => actionName.replace(resolvedName, '');
 
-export function unreject(actionName) {
-  return actionName.replace(REJECTED_NAME, '');
-}
+export const unreject = (actionName, rejectedName = REJECTED_NAME) => actionName.replace(rejectedName, '');
 
-export default function promiseMiddleware(resolvedName, rejectedName) {
-  [RESOLVED_NAME, REJECTED_NAME] = [resolvedName || RESOLVED_NAME, rejectedName || REJECTED_NAME];
-
-  return ({ dispatch }) => next => (action) => {
+export function createPromiseMiddleware(resolvedName = RESOLVED_NAME, rejectedName = REJECTED_NAME) {
+  const middleware = ({ dispatch }) => next => (action) => {
 
     if (!isFSA(action) || !action.payload || !isPromise(action.payload.promise)) {
       return next(action);
@@ -71,4 +62,16 @@ export default function promiseMiddleware(resolvedName, rejectedName) {
       }
     );
   };
+
+  middleware.RESOLVED_NAME = resolvedName;
+  middleware.REJECTED_NAME = rejectedName;
+
+  middleware.resolve = actionName => resolve(actionName, resolvedName);
+  middleware.reject = actionName => reject(actionName, rejectedName);
+  middleware.unresolve = actionName => unresolve(actionName, resolvedName);
+  middleware.unreject = actionName => unreject(actionName, rejectedName);
+
+  return middleware;
 }
+
+export default createPromiseMiddleware();


### PR DESCRIPTION
Hi,
Added an export for the resolved and rejected names.
Useful when using [redux-axios-middleware](https://github.com/svrcekmichal/redux-axios-middleware) and you want to provide matching suffixes.

Thanks!